### PR TITLE
Fix for incorrect XML config key names;

### DIFF
--- a/ContinuumXmlSlammer/Constants.cs
+++ b/ContinuumXmlSlammer/Constants.cs
@@ -8,9 +8,10 @@ namespace ContinuumXmlSlammer
 {
     public class Constants
     {
-        public static string SELECTEDFIELDKEY = "XmlSlammerSelectedField";
-        public static string PATHDELIMITERKEY = "XmlSlammerPathDelimiter";
-        public static string ATTRDELIMITERKEY = "XmlSlammerAttrDelimiter";
-        public static string FIELDNAMESKEY = "XmlSlammerFieldNames";
+        // NOTE: THESE STRINGS SHOULD MATCH THE ACCESSORS IN XmlInputConfiguration.cs
+        public static string SELECTEDFIELDKEY = "SelectedField";
+        public static string PATHDELIMITERKEY = "PathDelimiter";
+        public static string ATTRDELIMITERKEY = "AttrDelimiter";
+        public static string FIELDNAMESKEY = "FieldNames";
     }
 }

--- a/ContinuumXmlSlammer/XmlSlammerUserControl.Designer.cs
+++ b/ContinuumXmlSlammer/XmlSlammerUserControl.Designer.cs
@@ -29,6 +29,7 @@
         private void InitializeComponent()
         {
             this.panel1 = new System.Windows.Forms.Panel();
+            this.labelVersion = new System.Windows.Forms.Label();
             this.labelXmlSlammer = new System.Windows.Forms.Label();
             this.panel2 = new System.Windows.Forms.Panel();
             this.comboboxXmlSlammerField = new System.Windows.Forms.ComboBox();
@@ -39,7 +40,6 @@
             this.panel4 = new System.Windows.Forms.Panel();
             this.textboxXmlSlammerAttrDelim = new System.Windows.Forms.TextBox();
             this.labelXmlSlammerAttrDelim = new System.Windows.Forms.Label();
-            this.labelVersion = new System.Windows.Forms.Label();
             this.panel1.SuspendLayout();
             this.panel2.SuspendLayout();
             this.panel3.SuspendLayout();
@@ -54,6 +54,15 @@
             this.panel1.Name = "panel1";
             this.panel1.Size = new System.Drawing.Size(300, 50);
             this.panel1.TabIndex = 0;
+            // 
+            // labelVersion
+            // 
+            this.labelVersion.AutoSize = true;
+            this.labelVersion.Location = new System.Drawing.Point(158, 22);
+            this.labelVersion.Name = "labelVersion";
+            this.labelVersion.Size = new System.Drawing.Size(46, 13);
+            this.labelVersion.TabIndex = 1;
+            this.labelVersion.Text = "(v 1.0.2)";
             // 
             // labelXmlSlammer
             // 
@@ -142,15 +151,6 @@
             this.labelXmlSlammerAttrDelim.Size = new System.Drawing.Size(69, 13);
             this.labelXmlSlammerAttrDelim.TabIndex = 0;
             this.labelXmlSlammerAttrDelim.Text = "Attr Delimiter:";
-            // 
-            // labelVersion
-            // 
-            this.labelVersion.AutoSize = true;
-            this.labelVersion.Location = new System.Drawing.Point(158, 22);
-            this.labelVersion.Name = "labelVersion";
-            this.labelVersion.Size = new System.Drawing.Size(46, 13);
-            this.labelVersion.TabIndex = 1;
-            this.labelVersion.Text = "(v 1.0.1)";
             // 
             // XmlSlammerUserControl
             // 

--- a/ReadMe.MD
+++ b/ReadMe.MD
@@ -156,6 +156,13 @@ Steve Hibbert (steve at Continuum dot je), October 2017 (www.continuum.je)
 MIT License: Use as you see fit, give credit where applicable.
 
 
+## Updates
+
+### V 1.0.1: Alpha Release.
+
+### V 1.0.2: Fixed XML Config bug where Key names were not correct.
+
+
 
 ## Credits and Acknowledgements
 


### PR DESCRIPTION
BRANCH: 2018-08-06_LT3_XmlConfigNamesFix

CHANGED: ContinuumXmlSlammer/Constants.cs
 - Key names corrected

CHANGED: ContinuumXmlSlammer/XmlSlammerUserControl.Designer.cs
 - Version code updated to v 1.0.2

CHANGED: ReadMe.MD
 - Updated to reflect fix