### PR TITLE
Checkbox added to allow the choice to index repeating groups or not;

### DIFF
--- a/AlteryxTests/ColonBug/ColonBug.bak
+++ b/AlteryxTests/ColonBug/ColonBug.bak
@@ -7,6 +7,7 @@
       </GuiSettings>
       <Properties>
         <Configuration>
+          <IndexGroups>Y</IndexGroups>
           <FieldNames>Field_1</FieldNames>
           <SelectedField>Field_1</SelectedField>
           <PathDelimiter>\</PathDelimiter>
@@ -54,7 +55,7 @@
     </Node>
     <Node ToolID="3">
       <GuiSettings Plugin="AlteryxGuiToolkit.TextBox.TextBox">
-        <Position x="54" y="174" width="100" height="40" />
+        <Position x="78" y="210" width="312" height="96" />
       </GuiSettings>
       <Properties>
         <Configuration>

--- a/AlteryxTests/ColonBug/ColonBug.yxmd
+++ b/AlteryxTests/ColonBug/ColonBug.yxmd
@@ -7,9 +7,10 @@
       </GuiSettings>
       <Properties>
         <Configuration>
+          <IndexGroups>Y</IndexGroups>
           <FieldNames>Field_1</FieldNames>
           <SelectedField>Field_1</SelectedField>
-          <PathDelimiter>\</PathDelimiter>
+          <PathDelimiter>!</PathDelimiter>
           <AttrDelimiter>.</AttrDelimiter>
         </Configuration>
         <Annotation DisplayMode="0">

--- a/ContinuumXmlSlammer/Constants.cs
+++ b/ContinuumXmlSlammer/Constants.cs
@@ -12,7 +12,15 @@ namespace ContinuumXmlSlammer
         public static string SELECTEDFIELDKEY = "SelectedField";
         public static string PATHDELIMITERKEY = "PathDelimiter";
         public static string ATTRDELIMITERKEY = "AttrDelimiter";
-        public static string FIELDNAMESKEY = "FieldNames";
+        public static string FIELDNAMESKEY = "FieldNames"; // Last seen field
+        public static string INDEXGROUPSKEY = "IndexGroups";
+
+        // Default Values
+        public static string DEFAULTINDEXGROUPS = "Y";
+        public static string DEFAULTPATHDELIMITER = "/";
+        public static string DEFAULTATTRDELIMITER = ".";
+        public static string DEFAULTSELECTEDFIELD = "Field_1";
+        public static string DEFAULTFIELDNAMES = "Field_1";
 
         public static int LARGEOUTPUTFIELDSIZE = Int32.MaxValue;
         public static int SMALLOUTPUTFIELDSIZE = 512;

--- a/ContinuumXmlSlammer/XExtensions.cs
+++ b/ContinuumXmlSlammer/XExtensions.cs
@@ -24,7 +24,7 @@ namespace ContinuumXmlSlammer
         /// Get the absolute XPath to a given XElement, including the namespace.
         /// (e.g. "/a:people/b:person[6]/c:name[1]/d:last[1]").
         /// </summary>
-        public static string GetAbsoluteXPath(this XElement element, string delimiter="/")
+        public static string GetAbsoluteXPath(this XElement element, bool indexGroups, string delimiter="/")
         {
             if (element == null)
             {
@@ -51,11 +51,17 @@ namespace ContinuumXmlSlammer
                         namespacePrefix + ":" + e.Name.LocalName;
                 }
 
-                // If the element is the root or has no sibling elements, no index is required
-                return ((index == -1) || (index == -2)) ?
-                    delimiter + name :
-                    delimiter + name + delimiter + index.ToString();
-                    
+                // If the element is the root or has no sibling elements, no index is required.
+                // Additionally, only add an index if the flag is set.
+                if (indexGroups)
+                {
+                    return ((index == -1) || (index == -2)) ?
+                        delimiter + name :
+                        delimiter + name + delimiter + index.ToString();
+                }
+                else                
+                    return delimiter + name;
+                
             };
 
             var ancestors = from e in element.Ancestors() select relativeXPath(e);

--- a/ContinuumXmlSlammer/XmlInputConfiguration.cs
+++ b/ContinuumXmlSlammer/XmlInputConfiguration.cs
@@ -9,74 +9,63 @@ namespace ContinuumXmlSlammer
 {
     public class XmlInputConfiguration
     {
-        public string FieldNames { get; private set; }
         public string SelectedField { get; private set; }
         public string PathDelimiter { get; private set; }
         public string AttrDelimiter { get; private set; }
+        public string FieldNames { get; private set; }
+        public string IndexGroups { get; private set; }
 
         // Note that the constructor is private.  Instances are created through the LoadFromConfigration method.
-        private XmlInputConfiguration(string selectedField, string pathDelimiter, string attrDelimiter, string fieldNames)
+        private XmlInputConfiguration(
+            string selectedField, 
+            string pathDelimiter, 
+            string attrDelimiter, 
+            string fieldNames,
+            string indexGroups)
         {
             SelectedField = selectedField;
             PathDelimiter = pathDelimiter;
             AttrDelimiter = attrDelimiter;
             FieldNames = fieldNames;
+            IndexGroups = indexGroups;
         }
 
         public static XmlInputConfiguration LoadFromConfiguration(XmlElement eConfig)
         {
-            string pathDelimiter = "/";
-            string attrDelimiter = ".";
-            string selectedField = "DownloadData";
-            string fieldNames = "";
+            string pathDelimiter = getStringFromConfig(eConfig, Constants.PATHDELIMITERKEY, Constants.DEFAULTPATHDELIMITER);
+            string attrDelimiter = getStringFromConfig(eConfig, Constants.ATTRDELIMITERKEY, Constants.DEFAULTATTRDELIMITER);
+            string selectedField = getStringFromConfig(eConfig, Constants.SELECTEDFIELDKEY, Constants.DEFAULTSELECTEDFIELD);
+            string fieldNames = getStringFromConfig(eConfig, Constants.FIELDNAMESKEY, Constants.DEFAULTFIELDNAMES);
+            string indexGroups = getStringFromConfig(eConfig, Constants.INDEXGROUPSKEY, Constants.DEFAULTINDEXGROUPS);
 
-            // Get the saved pathDelimiter string
-            XmlElement xmlElement = eConfig.SelectSingleNode(Constants.PATHDELIMITERKEY) as XmlElement;
-
-            if (xmlElement != null)
-            {
-                if (!string.IsNullOrEmpty(xmlElement.InnerText))
-                {
-                    // We path have a Delimiter element and it contains text
-                    pathDelimiter = xmlElement.InnerText;
-                }
-            }
-
-
-            // Get the saved attrDelimiter string
-            xmlElement = eConfig.SelectSingleNode(Constants.ATTRDELIMITERKEY) as XmlElement;
-            if (xmlElement != null)
-            {
-                if (!string.IsNullOrEmpty(xmlElement.InnerText))
-                {
-                    attrDelimiter = xmlElement.InnerText;
-                }
-            }
-
-
-            // Get the saved SelectedField string
-            xmlElement = eConfig.SelectSingleNode(Constants.SELECTEDFIELDKEY) as XmlElement;
-
-            if (xmlElement != null)
-            {
-                if (!string.IsNullOrWhiteSpace(xmlElement.InnerText))
-                {
-                    selectedField = xmlElement.InnerText;
-                }
-            }
-
-            // Get the saved FieldNames string
-            xmlElement = eConfig.SelectSingleNode(Constants.FIELDNAMESKEY) as XmlElement;
-
-            if (xmlElement != null)
-            {
-                if (!string.IsNullOrWhiteSpace(xmlElement.InnerText))
-                {
-                    fieldNames = xmlElement.InnerText;
-                }
-            }
-
-            return new XmlInputConfiguration(selectedField, pathDelimiter, attrDelimiter, fieldNames);
+            return new XmlInputConfiguration(
+                selectedField, 
+                pathDelimiter, 
+                attrDelimiter, 
+                fieldNames, 
+                indexGroups);
         }
+
+        public static string getStringFromConfig(XmlElement eConfig, string key, string valueDefault)
+        {
+            string sReturn = valueDefault;
+
+            XmlElement xe = eConfig.SelectSingleNode(key) as XmlElement;
+            if (xe != null)
+            {
+                if (!string.IsNullOrEmpty(xe.InnerText))
+                    sReturn = xe.InnerText;
+            }
+
+            return sReturn;
+        }
+
+        // Property Name Accessor
+        public object this[string propertyName]
+        {
+            get { return this.GetType().GetProperty(propertyName).GetValue(this, null); }
+            set { this.GetType().GetProperty(propertyName).SetValue(this, value, null); }
+        }
+
     }
 }

--- a/ContinuumXmlSlammer/XmlSlammerNetPlugin.cs
+++ b/ContinuumXmlSlammer/XmlSlammerNetPlugin.cs
@@ -24,9 +24,12 @@ namespace ContinuumXmlSlammer
 
         private RecordCopier _recordCopier;
 
-        private string _selectedField;
-        private string _pathDelimiter = "/";
-        private string _attrDelimiter = ".";
+
+        private string _selectedField = Constants.DEFAULTSELECTEDFIELD;
+        private string _pathDelimiter = Constants.DEFAULTPATHDELIMITER;
+        private string _attrDelimiter = Constants.DEFAULTATTRDELIMITER;
+        private string _sIndexGroups = Constants.DEFAULTINDEXGROUPS;
+        private bool _indexGroups = true;
 
 
 
@@ -42,17 +45,13 @@ namespace ContinuumXmlSlammer
             XmlElement configElement = XmlHelpers.GetFirstChildByName(_xmlProperties, "Configuration", true);
             if (configElement != null)
             {
-                XmlElement selectedFieldElement = XmlHelpers.GetFirstChildByName(configElement, Constants.SELECTEDFIELDKEY, false);
-                if (selectedFieldElement != null)
-                    _selectedField = selectedFieldElement.InnerText;
+                getConfigSetting(configElement, Constants.SELECTEDFIELDKEY, ref _selectedField);
+                getConfigSetting(configElement, Constants.PATHDELIMITERKEY, ref _pathDelimiter);
+                getConfigSetting(configElement, Constants.ATTRDELIMITERKEY, ref _attrDelimiter);
 
-                XmlElement pathDelimiterElement = XmlHelpers.GetFirstChildByName(configElement, Constants.PATHDELIMITERKEY, false);
-                if (pathDelimiterElement != null)
-                    _pathDelimiter = pathDelimiterElement.InnerText;
+                getConfigSetting(configElement, Constants.INDEXGROUPSKEY, ref _sIndexGroups);
+                _indexGroups = isTrueString(_sIndexGroups);
 
-                XmlElement attrDelimiterElement = XmlHelpers.GetFirstChildByName(configElement, Constants.ATTRDELIMITERKEY, false);
-                if (attrDelimiterElement != null)
-                    _attrDelimiter = attrDelimiterElement.InnerText;
             }
 
             _outputHelper = new PluginOutputConnectionHelper(_toolID, _engineInterface);
@@ -131,7 +130,7 @@ namespace ContinuumXmlSlammer
 
             foreach (var xElement in doc.Root.DescendantsAndSelf())
             {
-                string xPath = xElement.GetAbsoluteXPath(_pathDelimiter); // The xml hierachy path
+                string xPath = xElement.GetAbsoluteXPath(_indexGroups, _pathDelimiter); // The xml hierachy path
                 string textContent = xElement.ShallowValue().Trim(); // Value in the text node
 
                 pushRecord(xPath, textContent, recordDataIn);
@@ -241,6 +240,33 @@ namespace ContinuumXmlSlammer
         }
 
 
+        //////////// 
+        // HELPERS
+
+        private void getConfigSetting(XmlElement configElement, string key, ref string memberToSet)
+        {
+            XmlElement xe = XmlHelpers.GetFirstChildByName(configElement, key, false);
+            if (xe != null)
+            {
+                if (!string.IsNullOrWhiteSpace(xe.InnerText))
+                    memberToSet = xe.InnerText;
+            }
+        }
+
+        public static bool isTrueString(string target)
+        {
+            string cleanTarget = target.Trim().ToUpper();
+            switch (cleanTarget)
+            {
+                case "Y":
+                case "TRUE":
+                case "1":
+                    return true;
+                default:
+                    break;
+            }
+            return false;
+        }
 
     }
 }

--- a/ContinuumXmlSlammer/XmlSlammerUserControl.Designer.cs
+++ b/ContinuumXmlSlammer/XmlSlammerUserControl.Designer.cs
@@ -40,10 +40,14 @@
             this.panel4 = new System.Windows.Forms.Panel();
             this.textboxXmlSlammerAttrDelim = new System.Windows.Forms.TextBox();
             this.labelXmlSlammerAttrDelim = new System.Windows.Forms.Label();
+            this.panel5 = new System.Windows.Forms.Panel();
+            this.labelXmlSlammerIndexGroups = new System.Windows.Forms.Label();
+            this.checkBoxIndexGroups = new System.Windows.Forms.CheckBox();
             this.panel1.SuspendLayout();
             this.panel2.SuspendLayout();
             this.panel3.SuspendLayout();
             this.panel4.SuspendLayout();
+            this.panel5.SuspendLayout();
             this.SuspendLayout();
             // 
             // panel1
@@ -62,7 +66,7 @@
             this.labelVersion.Name = "labelVersion";
             this.labelVersion.Size = new System.Drawing.Size(46, 13);
             this.labelVersion.TabIndex = 1;
-            this.labelVersion.Text = "(v 1.1.1)";
+            this.labelVersion.Text = "(v 1.2.0)";
             // 
             // labelXmlSlammer
             // 
@@ -152,16 +156,44 @@
             this.labelXmlSlammerAttrDelim.TabIndex = 0;
             this.labelXmlSlammerAttrDelim.Text = "Attr Delimiter:";
             // 
+            // panel5
+            // 
+            this.panel5.Controls.Add(this.checkBoxIndexGroups);
+            this.panel5.Controls.Add(this.labelXmlSlammerIndexGroups);
+            this.panel5.Location = new System.Drawing.Point(0, 200);
+            this.panel5.Name = "panel5";
+            this.panel5.Size = new System.Drawing.Size(300, 50);
+            this.panel5.TabIndex = 4;
+            // 
+            // labelXmlSlammerIndexGroups
+            // 
+            this.labelXmlSlammerIndexGroups.AutoSize = true;
+            this.labelXmlSlammerIndexGroups.Location = new System.Drawing.Point(8, 19);
+            this.labelXmlSlammerIndexGroups.Name = "labelXmlSlammerIndexGroups";
+            this.labelXmlSlammerIndexGroups.Size = new System.Drawing.Size(73, 13);
+            this.labelXmlSlammerIndexGroups.TabIndex = 0;
+            this.labelXmlSlammerIndexGroups.Text = "Index Groups:";
+            // 
+            // checkBoxIndexGroups
+            // 
+            this.checkBoxIndexGroups.AutoSize = true;
+            this.checkBoxIndexGroups.Location = new System.Drawing.Point(90, 19);
+            this.checkBoxIndexGroups.Name = "checkBoxIndexGroups";
+            this.checkBoxIndexGroups.Size = new System.Drawing.Size(15, 14);
+            this.checkBoxIndexGroups.TabIndex = 1;
+            this.checkBoxIndexGroups.UseVisualStyleBackColor = true;
+            // 
             // XmlSlammerUserControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.panel5);
             this.Controls.Add(this.panel4);
             this.Controls.Add(this.panel3);
             this.Controls.Add(this.panel2);
             this.Controls.Add(this.panel1);
             this.Name = "XmlSlammerUserControl";
-            this.Size = new System.Drawing.Size(300, 200);
+            this.Size = new System.Drawing.Size(300, 250);
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
             this.panel2.ResumeLayout(false);
@@ -170,6 +202,8 @@
             this.panel3.PerformLayout();
             this.panel4.ResumeLayout(false);
             this.panel4.PerformLayout();
+            this.panel5.ResumeLayout(false);
+            this.panel5.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -188,5 +222,8 @@
         private System.Windows.Forms.TextBox textboxXmlSlammerAttrDelim;
         private System.Windows.Forms.Label labelXmlSlammerAttrDelim;
         private System.Windows.Forms.Label labelVersion;
+        private System.Windows.Forms.Panel panel5;
+        private System.Windows.Forms.CheckBox checkBoxIndexGroups;
+        private System.Windows.Forms.Label labelXmlSlammerIndexGroups;
     }
 }

--- a/ContinuumXmlSlammer/XmlSlammerUserControl.cs
+++ b/ContinuumXmlSlammer/XmlSlammerUserControl.cs
@@ -100,6 +100,14 @@ namespace ContinuumXmlSlammer
             // Update the Attribute textbox.
             textboxXmlSlammerAttrDelim.Text = xmlConfig.AttrDelimiter;
 
+
+            /////////////
+            // CHECKBOX
+            //
+
+            setCheckbox(checkBoxIndexGroups, xmlConfig, Constants.INDEXGROUPSKEY, eIncomingMetaInfo);
+
+
             return this;
         }
 
@@ -115,6 +123,8 @@ namespace ContinuumXmlSlammer
 
         public void SaveResultsToXml(XmlElement eConfig, out string strDefaultAnnotation)
         {
+            saveSubForCheckbox(checkBoxIndexGroups, eConfig, Constants.INDEXGROUPSKEY, Constants.DEFAULTINDEXGROUPS);
+
             XmlElement xmlElementFieldNames = XmlHelpers.GetOrCreateChildNode(eConfig, Constants.FIELDNAMESKEY);
             List<string> fieldNames = new List<string>();
             foreach (var item in comboboxXmlSlammerField.Items)
@@ -136,6 +146,34 @@ namespace ContinuumXmlSlammer
 
             // Set the default annotation to be the name of the xml file.
             strDefaultAnnotation = "XML Slammer";
+        }
+
+        private void setCheckbox(CheckBox cb, XmlInputConfiguration xmlConfig, string key, XmlElement[] eIncomingMetaInfo)
+        {
+            string setting = (string)xmlConfig[key] ?? Constants.DEFAULTINDEXGROUPS; // Get the data held in the config (Y/N)
+
+            if (isTrueString(setting))
+                cb.Checked = true;
+            else
+                cb.Checked = false;
+        }
+
+        private bool isTrueString(string setting)
+        {
+            if (String.Equals(setting, "Y", StringComparison.OrdinalIgnoreCase)) return true;
+            if (String.Equals(setting, "1", StringComparison.OrdinalIgnoreCase)) return true;
+            if (String.Equals(setting, "true", StringComparison.OrdinalIgnoreCase)) return true;
+
+            return false;
+        }
+
+        private void saveSubForCheckbox(CheckBox cb, XmlElement eConfig, string key, string valueDefault)
+        {
+            XmlElement xe = XmlHelpers.GetOrCreateChildNode(eConfig, key);
+            if (cb.Checked == true)
+                xe.InnerText = "Y";
+            else
+                xe.InnerText = "N";
         }
     }
 }

--- a/ReadMe.MD
+++ b/ReadMe.MD
@@ -185,6 +185,9 @@ Record copy procedure updated to allow all record types through.  Additional fie
 ### V 1.1.1 (Updated 07-MAY-2019)
 Fixed problem where, if namespace was present but empty, a colon was added to each element separator.  Now the colon is only added if required, by checking for nullness.
 
+### V 1.2.0 (Updated 07-MAY-2019 also)
+Added checkbox to allow the choice to index repeating groups, or not.
+
 
 
 ## Credits and Acknowledgements


### PR DESCRIPTION
BRANCH: 2019-05-07_LT3_Added-IndexGroup-Checkbox

CHANGED: ContinuumXmlSlammer/Constants.cs
 - Constant added for INDEXGROUPSKEY.
 - Default constants added.

CHANGED: ContinuumXmlSlammer/XExtensions.cs
 - GetAbsoluteXPath() now conditionally adds group index based on input bool setting.

CHANGED: ContinuumXmlSlammer/XmlInputConfiguration.cs
 - getStringFromConfig() added.
 - LoadFromConfiguration() now calls getStringFromConfig() .
 - Property Name Accessor function added to allow other classes to use square bracket access.

CHANGED: ContinuumXmlSlammer/XmlSlammerNetPlugin.cs
 - Private variables set to default constant values.
 - getConfigSetting() helper added.
 - isTrueString() helper added.
 - PI_Init() now uses getConfigSetting() to standardise loading.
 - PI_Init() calls isTrueString() to set private member based on string setting.
 - II_PushRecord() calls GetAbsoluteXPath() with private bool flag to pass through indexGroups flag.

CHANGED: ContinuumXmlSlammer/XmlSlammerUserControl.Designer.cs
 - Checkbox added.
 - Label added.
 - Version code updated.

CHANGED: ContinuumXmlSlammer/XmlSlammerUserControl.cs
 - GetConfigurationControl() calls setCheckbox() to set checkbox from config.
 - SaveResultsToXml() calls saveSubForCheckbox() to save checkbox setting to config.
 - setCheckbox() added to enact setting.
 - isTrueString() added to convert string to bool.
 - saveSubForCheckbox() added to convert bool to string.

CHANGED: ReadMe.MD
 - Notes updated for version control.